### PR TITLE
20w45a compatibility. Bump to 0.8.5-pre.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 archivesBaseName = "libblockatttributes"
-version = "0.8.4"
+version = "0.8.5-pre.1"
 
 license {
     header = project.file('misc/LICENSE_HEADER.txt');
@@ -31,12 +31,12 @@ minecraft {
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:1.16.2"
-    mappings "net.fabricmc:yarn:1.16.2+build.19:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.9.1+build.205"
+    minecraft "com.mojang:minecraft:20w45a"
+    mappings "net.fabricmc:yarn:20w45a+build.7:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.10.6+build.214"
 
     //Fabric api
-    modImplementation "net.fabricmc.fabric-api:fabric-api:0.18.0+build.397-1.16"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:0.25.3+1.17"
 
     // Silk API
     modImplementation("io.github.prospector.silk:SilkAPI:${silk_version}") { transitive = false }
@@ -120,9 +120,9 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 
 new File("run/").mkdirs();
 
-test {
-    workingDir = "run/"
-}
+//test {
+//    workingDir = "run/"
+//}
 
 publishing {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 archivesBaseName = "libblockatttributes"
-version = "0.8.5-pre.1"
+version = "0.8.1700-pre.1"
 
 license {
     header = project.file('misc/LICENSE_HEADER.txt');
@@ -57,6 +57,7 @@ sourceSets {
         java {
             srcDir "src/main/java"
             srcDir "src/fatjar/java"
+            exclude "alexiil/mc/lib/attributes/fluid/compat/mod/reborncore/**"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -120,9 +120,9 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 
 new File("run/").mkdirs();
 
-//test {
-//    workingDir = "run/"
-//}
+test {
+    workingDir = "run/"
+}
 
 publishing {
     repositories {

--- a/src/main/java/alexiil/mc/lib/attributes/Attribute.java
+++ b/src/main/java/alexiil/mc/lib/attributes/Attribute.java
@@ -76,7 +76,7 @@ import alexiil.mc.lib.attributes.misc.UnmodifiableRef;
  * <li>If the block or item implements {@link AttributeProvider} or {@link AttributeProviderItem} directly then is is
  * used first. If that adder didn't add anything then the next steps aren't skipped (so it will exit early if the
  * block/item provided any implementations itself, otherwise it will continue to try to find one).</li>
- * <li>If the block is meant to have a {@link BlockEntity} ({@link Block#hasBlockEntity()}), and a {@link BlockEntity}
+ * <li>If the block state is meant to have a {@link BlockEntity} ({@link BlockState#method_31709()}), and a {@link BlockEntity}
  * is present in the world, and it implements {@link AttributeProviderBlockEntity} then it is checked second. If that
  * adder didn't add anything then the next steps aren't skipped (so it will exit early if the block entity provided any
  * implementations itself, otherwise it will continue to try to find one).</li>
@@ -308,7 +308,7 @@ public class Attribute<T> {
             }
         }
 
-        BlockEntity be = block.hasBlockEntity() ? world.getBlockEntity(pos) : null;
+        BlockEntity be = state.method_31709() ? world.getBlockEntity(pos) : null;
         if (be instanceof AttributeProviderBlockEntity) {
             ((AttributeProviderBlockEntity) be).addAllAttributes(list);
             if (list.hasOfferedAny()) {

--- a/src/main/java/alexiil/mc/lib/attributes/fluid/FluidInvUtil.java
+++ b/src/main/java/alexiil/mc/lib/attributes/fluid/FluidInvUtil.java
@@ -1714,7 +1714,7 @@ public final class FluidInvUtil {
         if (mainStack.isEmpty()) {
             return FluidTankInteraction.NONE;
         }
-        boolean isCreative = player.abilities.creativeMode;
+        boolean isCreative = player.method_31549().creativeMode;
         Reference<ItemStack> realRef = stack;
         if (isCreative) {
             realRef = Reference.callable(stack::get, ITEM_VOID, s -> true);

--- a/src/main/java/alexiil/mc/lib/attributes/fluid/compat/mod/LbaFluidModCompatLoader.java
+++ b/src/main/java/alexiil/mc/lib/attributes/fluid/compat/mod/LbaFluidModCompatLoader.java
@@ -26,6 +26,7 @@ public final class LbaFluidModCompatLoader {
             LibBlockAttributes.LOGGER.info("Silk not found, not loading compatibility for fluids.");
         }
 
-        RebornCompatLoader.load();
+        //FIXME: Fix reborn core compat once it updates to 1.17
+        //RebornCompatLoader.load();
     }
 }

--- a/src/main/java/alexiil/mc/lib/attributes/fluid/compat/mod/reborncore/RebornFluidCompat.java
+++ b/src/main/java/alexiil/mc/lib/attributes/fluid/compat/mod/reborncore/RebornFluidCompat.java
@@ -52,223 +52,223 @@ import reborncore.common.util.Tank;
     }
 
     private static <T> void addWrapper(MachineBaseBlockEntity machine, AttributeList<T> list) {
-//        Direction dir = list.getSearchDirection();
-//        if (dir == null) {
-//            return;
-//        }
-//        Direction side = dir.getOpposite();
-//
-//        Tank tank = machine.getTank();
-//        if (tank == null) {
-//            return;
-//        }
-//
-//        if (tank.getCapacity().getRawValue() <= 0) {
-//            return;
-//        }
-//        list.offer(new RebornFluidTankWrapper(side, machine, tank));
+        Direction dir = list.getSearchDirection();
+        if (dir == null) {
+            return;
+        }
+        Direction side = dir.getOpposite();
+
+        Tank tank = machine.getTank();
+        if (tank == null) {
+            return;
+        }
+
+        if (tank.getCapacity().getRawValue() <= 0) {
+            return;
+        }
+        list.offer(new RebornFluidTankWrapper(side, machine, tank));
     }
 
-//    static final class RebornFluidTankWrapper implements GroupedFluidInv, FixedFluidInv {
-//        private static final int REBORN_UNIT = 1000;
-//        private final Direction side;
-//        private final MachineBaseBlockEntity base;
-//        private final Tank tank;
-//
-//        RebornFluidTankWrapper(Direction side, MachineBaseBlockEntity base, Tank tank) {
-//            this.side = side;
-//            this.base = base;
-//            this.tank = tank;
-//        }
-//
-//        // FluidInsertable
-//
-//        @Override
-//        public FluidVolume attemptInsertion(FluidVolume fluid, Simulation simulation) {
-//            FluidValue max = base.fluidTransferAmount();
-//            if (max.getRawValue() <= 0) {
-//                return fluid;
-//            }
-//            // TODO: Filters!
-//            // (Although that would need RebornCore to add a filtering method...
-//            Fluid rawFluid = fluid.getFluidKey().getRawFluid();
-//            if (rawFluid == null) {
-//                return fluid;
-//            }
-//            FluidInstance fi = tank.getFluidInstance();
-//            int tankAmount = fi.getAmount().getRawValue();
-//            int space = tank.getCapacity().getRawValue() - tankAmount;
-//            if (space <= 0) {
-//                return fluid;
-//            }
-//            if (tankAmount > 0 && fi.getFluid() != rawFluid) {
-//                return fluid;
-//            }
-//            FluidConfiguration cfg = base.fluidConfiguration;
-//            ExtractConfig ioConfig = cfg != null ? cfg.getSideDetail(side).getIoConfig() : ExtractConfig.ALL;
-//            if (ioConfig.isInsert()) {
-//                int offeredAmount = fluid.getAmount_F().asInt(REBORN_UNIT, RoundingMode.DOWN);
-//                if (offeredAmount > space) {
-//                    offeredAmount = space;
-//                }
-//                if (offeredAmount > max.getRawValue()) {
-//                    offeredAmount = max.getRawValue();
-//                }
-//                FluidVolume ret = fluid.copy();
-//                FluidVolume offered = ret.split(FluidAmount.of(offeredAmount, REBORN_UNIT));
-//
-//                FluidAmount mul = offered.getAmount_F().checkedMul(REBORN_UNIT);
-//                assert mul.whole == offeredAmount : "Bad split! (whole)";
-//                assert mul.numerator == 0 : "Bad split! (numerator)";
-//
-//                if (simulation.isAction()) {
-//                    FluidValue val = FluidValue.fromRaw(offeredAmount);
-//                    if (tankAmount <= 0) {
-//                        fi = new FluidInstance(rawFluid, val);
-//                    } else {
-//                        fi.addAmount(val);
-//                    }
-//                    tank.setFluid(side, fi);
-//                }
-//                return ret;
-//            }
-//            return fluid;
-//        }
-//
-//        // FluidExtractable
-//
-//        @Override
-//        public FluidVolume attemptExtraction(FluidFilter filter, FluidAmount maxAmount, Simulation simulation) {
-//            FluidValue max = base.fluidTransferAmount();
-//            if (max.getRawValue() <= 0) {
-//                return FluidVolumeUtil.EMPTY;
-//            }
-//            FluidInstance fi = tank.getFluidInstance();
-//            int tankAmount = fi.getAmount().getRawValue();
-//            if (tankAmount <= 0) {
-//                return FluidVolumeUtil.EMPTY;
-//            }
-//            int available
-//                = Math.min(tankAmount, Math.min(max.getRawValue(), maxAmount.asInt(REBORN_UNIT, RoundingMode.DOWN)));
-//            if (available <= 0) {
-//                return FluidVolumeUtil.EMPTY;
-//            }
-//            FluidKey key = FluidKeys.get(tank.getFluid());
-//            if (!filter.matches(key)) {
-//                return FluidVolumeUtil.EMPTY;
-//            }
-//            FluidConfiguration cfg = base.fluidConfiguration;
-//            ExtractConfig ioConfig = cfg != null ? cfg.getSideDetail(side).getIoConfig() : ExtractConfig.ALL;
-//            if (ioConfig.isExtact()) {
-//                FluidVolume volume = key.withAmount(FluidAmount.of(available, REBORN_UNIT));
-//                if (simulation.isAction()) {
-//                    fi.subtractAmount(FluidValue.fromRaw(available));
-//                    tank.setFluid(side, fi);
-//                }
-//                return volume;
-//            }
-//            return FluidVolumeUtil.EMPTY;
-//        }
-//
-//        // GroupedFluidInvView
-//
-//        @Override
-//        public Set<FluidKey> getStoredFluids() {
-//            FluidInstance fi = tank.getFluidInstance();
-//            int amount = fi.getAmount().getRawValue();
-//            if (amount <= 0) {
-//                return Collections.emptySet();
-//            } else {
-//                return Collections.singleton(FluidKeys.get(fi.getFluid()));
-//            }
-//        }
-//
-//        @Override
-//        public FluidInvStatistic getStatistics(FluidFilter filter) {
-//            FluidInstance fi = tank.getFluidInstance();
-//            int amount = fi.getAmount().getRawValue();
-//            if (amount <= 0) {
-//                FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
-//                return new FluidInvStatistic(filter, FluidAmount.ZERO, capacity, capacity);
-//            } else {
-//                FluidKey key = FluidKeys.get(fi.getFluid());
-//                if (filter.matches(key)) {
-//                    FluidAmount fa = FluidAmount.of(amount, REBORN_UNIT);
-//                    FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
-//                    return new FluidInvStatistic(filter, fa, capacity, capacity);
-//                } else {
-//                    FluidAmount fa = FluidAmount.of(amount, REBORN_UNIT);
-//                    FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
-//                    return new FluidInvStatistic(filter, FluidAmount.ZERO, FluidAmount.ZERO, capacity);
-//                }
-//            }
-//        }
-//
-//        // FixedFluidInvView
-//
-//        @Override
-//        public int getTankCount() {
-//            return 1;
-//        }
-//
-//        @Override
-//        public FluidVolume getInvFluid(int t) {
-//            FluidInstance fi = tank.getFluidInstance();
-//            int amount = fi.getAmount().getRawValue();
-//            if (amount <= 0) {
-//                return FluidVolumeUtil.EMPTY;
-//            } else {
-//                return FluidKeys.get(fi.getFluid()).withAmount(FluidAmount.of(amount, REBORN_UNIT));
-//            }
-//        }
-//
-//        @Override
-//        public ListenerToken addListener(FluidInvTankChangeListener listener, ListenerRemovalToken removalToken) {
-//            return null;
-//        }
-//
-//        @Override
-//        public boolean isFluidValidForTank(int tank, FluidKey fluid) {
-//            return true; // Unfortunately we don't have filters :(
-//        }
-//
-//        // FixedFluidInv
-//
-//        @Override
-//        public boolean setInvFluid(int t, FluidVolume to, Simulation simulation) {
-//            if (to.isEmpty()) {
-//                if (simulation.isAction()) {
-//                    tank.setFluid(side, new FluidInstance());
-//                }
-//                return true;
-//            }
-//            FluidAmount mul = to.getAmount_F().saturatedMul(REBORN_UNIT);
-//            if (mul.numerator != 0) {
-//                return false;
-//            }
-//            if (mul.whole > Integer.MAX_VALUE) {
-//                return false;
-//            }
-//            Fluid raw = to.getRawFluid();
-//            if (raw == null) {
-//                return false;
-//            }
-//            if (simulation.isAction()) {
-//                FluidInstance fi = tank.getFluidInstance();
-//                FluidValue value = FluidValue.fromRaw((int) mul.whole);
-//                if (fi.getFluid().equals(raw)) {
-//                    // So we keep the tag
-//                    fi.setAmount(value);
-//                } else {
-//                    tank.setFluid(side, new FluidInstance(raw, value));
-//                }
-//            }
-//            return true;
-//        }
-//
-//        @Override
-//        public GroupedFluidInv getGroupedInv() {
-//            return this;
-//        }
-//    }
+    static final class RebornFluidTankWrapper implements GroupedFluidInv, FixedFluidInv {
+        private static final int REBORN_UNIT = 1000;
+        private final Direction side;
+        private final MachineBaseBlockEntity base;
+        private final Tank tank;
+
+        RebornFluidTankWrapper(Direction side, MachineBaseBlockEntity base, Tank tank) {
+            this.side = side;
+            this.base = base;
+            this.tank = tank;
+        }
+
+        // FluidInsertable
+
+        @Override
+        public FluidVolume attemptInsertion(FluidVolume fluid, Simulation simulation) {
+            FluidValue max = base.fluidTransferAmount();
+            if (max.getRawValue() <= 0) {
+                return fluid;
+            }
+            // TODO: Filters!
+            // (Although that would need RebornCore to add a filtering method...
+            Fluid rawFluid = fluid.getFluidKey().getRawFluid();
+            if (rawFluid == null) {
+                return fluid;
+            }
+            FluidInstance fi = tank.getFluidInstance();
+            int tankAmount = fi.getAmount().getRawValue();
+            int space = tank.getCapacity().getRawValue() - tankAmount;
+            if (space <= 0) {
+                return fluid;
+            }
+            if (tankAmount > 0 && fi.getFluid() != rawFluid) {
+                return fluid;
+            }
+            FluidConfiguration cfg = base.fluidConfiguration;
+            ExtractConfig ioConfig = cfg != null ? cfg.getSideDetail(side).getIoConfig() : ExtractConfig.ALL;
+            if (ioConfig.isInsert()) {
+                int offeredAmount = fluid.getAmount_F().asInt(REBORN_UNIT, RoundingMode.DOWN);
+                if (offeredAmount > space) {
+                    offeredAmount = space;
+                }
+                if (offeredAmount > max.getRawValue()) {
+                    offeredAmount = max.getRawValue();
+                }
+                FluidVolume ret = fluid.copy();
+                FluidVolume offered = ret.split(FluidAmount.of(offeredAmount, REBORN_UNIT));
+
+                FluidAmount mul = offered.getAmount_F().checkedMul(REBORN_UNIT);
+                assert mul.whole == offeredAmount : "Bad split! (whole)";
+                assert mul.numerator == 0 : "Bad split! (numerator)";
+
+                if (simulation.isAction()) {
+                    FluidValue val = FluidValue.fromRaw(offeredAmount);
+                    if (tankAmount <= 0) {
+                        fi = new FluidInstance(rawFluid, val);
+                    } else {
+                        fi.addAmount(val);
+                    }
+                    tank.setFluid(side, fi);
+                }
+                return ret;
+            }
+            return fluid;
+        }
+
+        // FluidExtractable
+
+        @Override
+        public FluidVolume attemptExtraction(FluidFilter filter, FluidAmount maxAmount, Simulation simulation) {
+            FluidValue max = base.fluidTransferAmount();
+            if (max.getRawValue() <= 0) {
+                return FluidVolumeUtil.EMPTY;
+            }
+            FluidInstance fi = tank.getFluidInstance();
+            int tankAmount = fi.getAmount().getRawValue();
+            if (tankAmount <= 0) {
+                return FluidVolumeUtil.EMPTY;
+            }
+            int available
+                = Math.min(tankAmount, Math.min(max.getRawValue(), maxAmount.asInt(REBORN_UNIT, RoundingMode.DOWN)));
+            if (available <= 0) {
+                return FluidVolumeUtil.EMPTY;
+            }
+            FluidKey key = FluidKeys.get(tank.getFluid());
+            if (!filter.matches(key)) {
+                return FluidVolumeUtil.EMPTY;
+            }
+            FluidConfiguration cfg = base.fluidConfiguration;
+            ExtractConfig ioConfig = cfg != null ? cfg.getSideDetail(side).getIoConfig() : ExtractConfig.ALL;
+            if (ioConfig.isExtact()) {
+                FluidVolume volume = key.withAmount(FluidAmount.of(available, REBORN_UNIT));
+                if (simulation.isAction()) {
+                    fi.subtractAmount(FluidValue.fromRaw(available));
+                    tank.setFluid(side, fi);
+                }
+                return volume;
+            }
+            return FluidVolumeUtil.EMPTY;
+        }
+
+        // GroupedFluidInvView
+
+        @Override
+        public Set<FluidKey> getStoredFluids() {
+            FluidInstance fi = tank.getFluidInstance();
+            int amount = fi.getAmount().getRawValue();
+            if (amount <= 0) {
+                return Collections.emptySet();
+            } else {
+                return Collections.singleton(FluidKeys.get(fi.getFluid()));
+            }
+        }
+
+        @Override
+        public FluidInvStatistic getStatistics(FluidFilter filter) {
+            FluidInstance fi = tank.getFluidInstance();
+            int amount = fi.getAmount().getRawValue();
+            if (amount <= 0) {
+                FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
+                return new FluidInvStatistic(filter, FluidAmount.ZERO, capacity, capacity);
+            } else {
+                FluidKey key = FluidKeys.get(fi.getFluid());
+                if (filter.matches(key)) {
+                    FluidAmount fa = FluidAmount.of(amount, REBORN_UNIT);
+                    FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
+                    return new FluidInvStatistic(filter, fa, capacity, capacity);
+                } else {
+                    FluidAmount fa = FluidAmount.of(amount, REBORN_UNIT);
+                    FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
+                    return new FluidInvStatistic(filter, FluidAmount.ZERO, FluidAmount.ZERO, capacity);
+                }
+            }
+        }
+
+        // FixedFluidInvView
+
+        @Override
+        public int getTankCount() {
+            return 1;
+        }
+
+        @Override
+        public FluidVolume getInvFluid(int t) {
+            FluidInstance fi = tank.getFluidInstance();
+            int amount = fi.getAmount().getRawValue();
+            if (amount <= 0) {
+                return FluidVolumeUtil.EMPTY;
+            } else {
+                return FluidKeys.get(fi.getFluid()).withAmount(FluidAmount.of(amount, REBORN_UNIT));
+            }
+        }
+
+        @Override
+        public ListenerToken addListener(FluidInvTankChangeListener listener, ListenerRemovalToken removalToken) {
+            return null;
+        }
+
+        @Override
+        public boolean isFluidValidForTank(int tank, FluidKey fluid) {
+            return true; // Unfortunately we don't have filters :(
+        }
+
+        // FixedFluidInv
+
+        @Override
+        public boolean setInvFluid(int t, FluidVolume to, Simulation simulation) {
+            if (to.isEmpty()) {
+                if (simulation.isAction()) {
+                    tank.setFluid(side, new FluidInstance());
+                }
+                return true;
+            }
+            FluidAmount mul = to.getAmount_F().saturatedMul(REBORN_UNIT);
+            if (mul.numerator != 0) {
+                return false;
+            }
+            if (mul.whole > Integer.MAX_VALUE) {
+                return false;
+            }
+            Fluid raw = to.getRawFluid();
+            if (raw == null) {
+                return false;
+            }
+            if (simulation.isAction()) {
+                FluidInstance fi = tank.getFluidInstance();
+                FluidValue value = FluidValue.fromRaw((int) mul.whole);
+                if (fi.getFluid().equals(raw)) {
+                    // So we keep the tag
+                    fi.setAmount(value);
+                } else {
+                    tank.setFluid(side, new FluidInstance(raw, value));
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public GroupedFluidInv getGroupedInv() {
+            return this;
+        }
+    }
 }

--- a/src/main/java/alexiil/mc/lib/attributes/fluid/compat/mod/reborncore/RebornFluidCompat.java
+++ b/src/main/java/alexiil/mc/lib/attributes/fluid/compat/mod/reborncore/RebornFluidCompat.java
@@ -52,223 +52,223 @@ import reborncore.common.util.Tank;
     }
 
     private static <T> void addWrapper(MachineBaseBlockEntity machine, AttributeList<T> list) {
-        Direction dir = list.getSearchDirection();
-        if (dir == null) {
-            return;
-        }
-        Direction side = dir.getOpposite();
-
-        Tank tank = machine.getTank();
-        if (tank == null) {
-            return;
-        }
-
-        if (tank.getCapacity().getRawValue() <= 0) {
-            return;
-        }
-        list.offer(new RebornFluidTankWrapper(side, machine, tank));
+//        Direction dir = list.getSearchDirection();
+//        if (dir == null) {
+//            return;
+//        }
+//        Direction side = dir.getOpposite();
+//
+//        Tank tank = machine.getTank();
+//        if (tank == null) {
+//            return;
+//        }
+//
+//        if (tank.getCapacity().getRawValue() <= 0) {
+//            return;
+//        }
+//        list.offer(new RebornFluidTankWrapper(side, machine, tank));
     }
 
-    static final class RebornFluidTankWrapper implements GroupedFluidInv, FixedFluidInv {
-        private static final int REBORN_UNIT = 1000;
-        private final Direction side;
-        private final MachineBaseBlockEntity base;
-        private final Tank tank;
-
-        RebornFluidTankWrapper(Direction side, MachineBaseBlockEntity base, Tank tank) {
-            this.side = side;
-            this.base = base;
-            this.tank = tank;
-        }
-
-        // FluidInsertable
-
-        @Override
-        public FluidVolume attemptInsertion(FluidVolume fluid, Simulation simulation) {
-            FluidValue max = base.fluidTransferAmount();
-            if (max.getRawValue() <= 0) {
-                return fluid;
-            }
-            // TODO: Filters!
-            // (Although that would need RebornCore to add a filtering method...
-            Fluid rawFluid = fluid.getFluidKey().getRawFluid();
-            if (rawFluid == null) {
-                return fluid;
-            }
-            FluidInstance fi = tank.getFluidInstance();
-            int tankAmount = fi.getAmount().getRawValue();
-            int space = tank.getCapacity().getRawValue() - tankAmount;
-            if (space <= 0) {
-                return fluid;
-            }
-            if (tankAmount > 0 && fi.getFluid() != rawFluid) {
-                return fluid;
-            }
-            FluidConfiguration cfg = base.fluidConfiguration;
-            ExtractConfig ioConfig = cfg != null ? cfg.getSideDetail(side).getIoConfig() : ExtractConfig.ALL;
-            if (ioConfig.isInsert()) {
-                int offeredAmount = fluid.getAmount_F().asInt(REBORN_UNIT, RoundingMode.DOWN);
-                if (offeredAmount > space) {
-                    offeredAmount = space;
-                }
-                if (offeredAmount > max.getRawValue()) {
-                    offeredAmount = max.getRawValue();
-                }
-                FluidVolume ret = fluid.copy();
-                FluidVolume offered = ret.split(FluidAmount.of(offeredAmount, REBORN_UNIT));
-
-                FluidAmount mul = offered.getAmount_F().checkedMul(REBORN_UNIT);
-                assert mul.whole == offeredAmount : "Bad split! (whole)";
-                assert mul.numerator == 0 : "Bad split! (numerator)";
-
-                if (simulation.isAction()) {
-                    FluidValue val = FluidValue.fromRaw(offeredAmount);
-                    if (tankAmount <= 0) {
-                        fi = new FluidInstance(rawFluid, val);
-                    } else {
-                        fi.addAmount(val);
-                    }
-                    tank.setFluid(side, fi);
-                }
-                return ret;
-            }
-            return fluid;
-        }
-
-        // FluidExtractable
-
-        @Override
-        public FluidVolume attemptExtraction(FluidFilter filter, FluidAmount maxAmount, Simulation simulation) {
-            FluidValue max = base.fluidTransferAmount();
-            if (max.getRawValue() <= 0) {
-                return FluidVolumeUtil.EMPTY;
-            }
-            FluidInstance fi = tank.getFluidInstance();
-            int tankAmount = fi.getAmount().getRawValue();
-            if (tankAmount <= 0) {
-                return FluidVolumeUtil.EMPTY;
-            }
-            int available
-                = Math.min(tankAmount, Math.min(max.getRawValue(), maxAmount.asInt(REBORN_UNIT, RoundingMode.DOWN)));
-            if (available <= 0) {
-                return FluidVolumeUtil.EMPTY;
-            }
-            FluidKey key = FluidKeys.get(tank.getFluid());
-            if (!filter.matches(key)) {
-                return FluidVolumeUtil.EMPTY;
-            }
-            FluidConfiguration cfg = base.fluidConfiguration;
-            ExtractConfig ioConfig = cfg != null ? cfg.getSideDetail(side).getIoConfig() : ExtractConfig.ALL;
-            if (ioConfig.isExtact()) {
-                FluidVolume volume = key.withAmount(FluidAmount.of(available, REBORN_UNIT));
-                if (simulation.isAction()) {
-                    fi.subtractAmount(FluidValue.fromRaw(available));
-                    tank.setFluid(side, fi);
-                }
-                return volume;
-            }
-            return FluidVolumeUtil.EMPTY;
-        }
-
-        // GroupedFluidInvView
-
-        @Override
-        public Set<FluidKey> getStoredFluids() {
-            FluidInstance fi = tank.getFluidInstance();
-            int amount = fi.getAmount().getRawValue();
-            if (amount <= 0) {
-                return Collections.emptySet();
-            } else {
-                return Collections.singleton(FluidKeys.get(fi.getFluid()));
-            }
-        }
-
-        @Override
-        public FluidInvStatistic getStatistics(FluidFilter filter) {
-            FluidInstance fi = tank.getFluidInstance();
-            int amount = fi.getAmount().getRawValue();
-            if (amount <= 0) {
-                FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
-                return new FluidInvStatistic(filter, FluidAmount.ZERO, capacity, capacity);
-            } else {
-                FluidKey key = FluidKeys.get(fi.getFluid());
-                if (filter.matches(key)) {
-                    FluidAmount fa = FluidAmount.of(amount, REBORN_UNIT);
-                    FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
-                    return new FluidInvStatistic(filter, fa, capacity, capacity);
-                } else {
-                    FluidAmount fa = FluidAmount.of(amount, REBORN_UNIT);
-                    FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
-                    return new FluidInvStatistic(filter, FluidAmount.ZERO, FluidAmount.ZERO, capacity);
-                }
-            }
-        }
-
-        // FixedFluidInvView
-
-        @Override
-        public int getTankCount() {
-            return 1;
-        }
-
-        @Override
-        public FluidVolume getInvFluid(int t) {
-            FluidInstance fi = tank.getFluidInstance();
-            int amount = fi.getAmount().getRawValue();
-            if (amount <= 0) {
-                return FluidVolumeUtil.EMPTY;
-            } else {
-                return FluidKeys.get(fi.getFluid()).withAmount(FluidAmount.of(amount, REBORN_UNIT));
-            }
-        }
-
-        @Override
-        public ListenerToken addListener(FluidInvTankChangeListener listener, ListenerRemovalToken removalToken) {
-            return null;
-        }
-
-        @Override
-        public boolean isFluidValidForTank(int tank, FluidKey fluid) {
-            return true; // Unfortunately we don't have filters :(
-        }
-
-        // FixedFluidInv
-
-        @Override
-        public boolean setInvFluid(int t, FluidVolume to, Simulation simulation) {
-            if (to.isEmpty()) {
-                if (simulation.isAction()) {
-                    tank.setFluid(side, new FluidInstance());
-                }
-                return true;
-            }
-            FluidAmount mul = to.getAmount_F().saturatedMul(REBORN_UNIT);
-            if (mul.numerator != 0) {
-                return false;
-            }
-            if (mul.whole > Integer.MAX_VALUE) {
-                return false;
-            }
-            Fluid raw = to.getRawFluid();
-            if (raw == null) {
-                return false;
-            }
-            if (simulation.isAction()) {
-                FluidInstance fi = tank.getFluidInstance();
-                FluidValue value = FluidValue.fromRaw((int) mul.whole);
-                if (fi.getFluid().equals(raw)) {
-                    // So we keep the tag
-                    fi.setAmount(value);
-                } else {
-                    tank.setFluid(side, new FluidInstance(raw, value));
-                }
-            }
-            return true;
-        }
-
-        @Override
-        public GroupedFluidInv getGroupedInv() {
-            return this;
-        }
-    }
+//    static final class RebornFluidTankWrapper implements GroupedFluidInv, FixedFluidInv {
+//        private static final int REBORN_UNIT = 1000;
+//        private final Direction side;
+//        private final MachineBaseBlockEntity base;
+//        private final Tank tank;
+//
+//        RebornFluidTankWrapper(Direction side, MachineBaseBlockEntity base, Tank tank) {
+//            this.side = side;
+//            this.base = base;
+//            this.tank = tank;
+//        }
+//
+//        // FluidInsertable
+//
+//        @Override
+//        public FluidVolume attemptInsertion(FluidVolume fluid, Simulation simulation) {
+//            FluidValue max = base.fluidTransferAmount();
+//            if (max.getRawValue() <= 0) {
+//                return fluid;
+//            }
+//            // TODO: Filters!
+//            // (Although that would need RebornCore to add a filtering method...
+//            Fluid rawFluid = fluid.getFluidKey().getRawFluid();
+//            if (rawFluid == null) {
+//                return fluid;
+//            }
+//            FluidInstance fi = tank.getFluidInstance();
+//            int tankAmount = fi.getAmount().getRawValue();
+//            int space = tank.getCapacity().getRawValue() - tankAmount;
+//            if (space <= 0) {
+//                return fluid;
+//            }
+//            if (tankAmount > 0 && fi.getFluid() != rawFluid) {
+//                return fluid;
+//            }
+//            FluidConfiguration cfg = base.fluidConfiguration;
+//            ExtractConfig ioConfig = cfg != null ? cfg.getSideDetail(side).getIoConfig() : ExtractConfig.ALL;
+//            if (ioConfig.isInsert()) {
+//                int offeredAmount = fluid.getAmount_F().asInt(REBORN_UNIT, RoundingMode.DOWN);
+//                if (offeredAmount > space) {
+//                    offeredAmount = space;
+//                }
+//                if (offeredAmount > max.getRawValue()) {
+//                    offeredAmount = max.getRawValue();
+//                }
+//                FluidVolume ret = fluid.copy();
+//                FluidVolume offered = ret.split(FluidAmount.of(offeredAmount, REBORN_UNIT));
+//
+//                FluidAmount mul = offered.getAmount_F().checkedMul(REBORN_UNIT);
+//                assert mul.whole == offeredAmount : "Bad split! (whole)";
+//                assert mul.numerator == 0 : "Bad split! (numerator)";
+//
+//                if (simulation.isAction()) {
+//                    FluidValue val = FluidValue.fromRaw(offeredAmount);
+//                    if (tankAmount <= 0) {
+//                        fi = new FluidInstance(rawFluid, val);
+//                    } else {
+//                        fi.addAmount(val);
+//                    }
+//                    tank.setFluid(side, fi);
+//                }
+//                return ret;
+//            }
+//            return fluid;
+//        }
+//
+//        // FluidExtractable
+//
+//        @Override
+//        public FluidVolume attemptExtraction(FluidFilter filter, FluidAmount maxAmount, Simulation simulation) {
+//            FluidValue max = base.fluidTransferAmount();
+//            if (max.getRawValue() <= 0) {
+//                return FluidVolumeUtil.EMPTY;
+//            }
+//            FluidInstance fi = tank.getFluidInstance();
+//            int tankAmount = fi.getAmount().getRawValue();
+//            if (tankAmount <= 0) {
+//                return FluidVolumeUtil.EMPTY;
+//            }
+//            int available
+//                = Math.min(tankAmount, Math.min(max.getRawValue(), maxAmount.asInt(REBORN_UNIT, RoundingMode.DOWN)));
+//            if (available <= 0) {
+//                return FluidVolumeUtil.EMPTY;
+//            }
+//            FluidKey key = FluidKeys.get(tank.getFluid());
+//            if (!filter.matches(key)) {
+//                return FluidVolumeUtil.EMPTY;
+//            }
+//            FluidConfiguration cfg = base.fluidConfiguration;
+//            ExtractConfig ioConfig = cfg != null ? cfg.getSideDetail(side).getIoConfig() : ExtractConfig.ALL;
+//            if (ioConfig.isExtact()) {
+//                FluidVolume volume = key.withAmount(FluidAmount.of(available, REBORN_UNIT));
+//                if (simulation.isAction()) {
+//                    fi.subtractAmount(FluidValue.fromRaw(available));
+//                    tank.setFluid(side, fi);
+//                }
+//                return volume;
+//            }
+//            return FluidVolumeUtil.EMPTY;
+//        }
+//
+//        // GroupedFluidInvView
+//
+//        @Override
+//        public Set<FluidKey> getStoredFluids() {
+//            FluidInstance fi = tank.getFluidInstance();
+//            int amount = fi.getAmount().getRawValue();
+//            if (amount <= 0) {
+//                return Collections.emptySet();
+//            } else {
+//                return Collections.singleton(FluidKeys.get(fi.getFluid()));
+//            }
+//        }
+//
+//        @Override
+//        public FluidInvStatistic getStatistics(FluidFilter filter) {
+//            FluidInstance fi = tank.getFluidInstance();
+//            int amount = fi.getAmount().getRawValue();
+//            if (amount <= 0) {
+//                FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
+//                return new FluidInvStatistic(filter, FluidAmount.ZERO, capacity, capacity);
+//            } else {
+//                FluidKey key = FluidKeys.get(fi.getFluid());
+//                if (filter.matches(key)) {
+//                    FluidAmount fa = FluidAmount.of(amount, REBORN_UNIT);
+//                    FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
+//                    return new FluidInvStatistic(filter, fa, capacity, capacity);
+//                } else {
+//                    FluidAmount fa = FluidAmount.of(amount, REBORN_UNIT);
+//                    FluidAmount capacity = FluidAmount.of(tank.getCapacity().getRawValue(), REBORN_UNIT);
+//                    return new FluidInvStatistic(filter, FluidAmount.ZERO, FluidAmount.ZERO, capacity);
+//                }
+//            }
+//        }
+//
+//        // FixedFluidInvView
+//
+//        @Override
+//        public int getTankCount() {
+//            return 1;
+//        }
+//
+//        @Override
+//        public FluidVolume getInvFluid(int t) {
+//            FluidInstance fi = tank.getFluidInstance();
+//            int amount = fi.getAmount().getRawValue();
+//            if (amount <= 0) {
+//                return FluidVolumeUtil.EMPTY;
+//            } else {
+//                return FluidKeys.get(fi.getFluid()).withAmount(FluidAmount.of(amount, REBORN_UNIT));
+//            }
+//        }
+//
+//        @Override
+//        public ListenerToken addListener(FluidInvTankChangeListener listener, ListenerRemovalToken removalToken) {
+//            return null;
+//        }
+//
+//        @Override
+//        public boolean isFluidValidForTank(int tank, FluidKey fluid) {
+//            return true; // Unfortunately we don't have filters :(
+//        }
+//
+//        // FixedFluidInv
+//
+//        @Override
+//        public boolean setInvFluid(int t, FluidVolume to, Simulation simulation) {
+//            if (to.isEmpty()) {
+//                if (simulation.isAction()) {
+//                    tank.setFluid(side, new FluidInstance());
+//                }
+//                return true;
+//            }
+//            FluidAmount mul = to.getAmount_F().saturatedMul(REBORN_UNIT);
+//            if (mul.numerator != 0) {
+//                return false;
+//            }
+//            if (mul.whole > Integer.MAX_VALUE) {
+//                return false;
+//            }
+//            Fluid raw = to.getRawFluid();
+//            if (raw == null) {
+//                return false;
+//            }
+//            if (simulation.isAction()) {
+//                FluidInstance fi = tank.getFluidInstance();
+//                FluidValue value = FluidValue.fromRaw((int) mul.whole);
+//                if (fi.getFluid().equals(raw)) {
+//                    // So we keep the tag
+//                    fi.setAmount(value);
+//                } else {
+//                    tank.setFluid(side, new FluidInstance(raw, value));
+//                }
+//            }
+//            return true;
+//        }
+//
+//        @Override
+//        public GroupedFluidInv getGroupedInv() {
+//            return this;
+//        }
+//    }
 }

--- a/src/main/java/alexiil/mc/lib/attributes/fluid/compat/mod/vanilla/VanillaFluidCompat.java
+++ b/src/main/java/alexiil/mc/lib/attributes/fluid/compat/mod/vanilla/VanillaFluidCompat.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
-import net.minecraft.block.CauldronBlock;
+import net.minecraft.block.WaterCauldronBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.potion.Potion;
@@ -176,7 +176,7 @@ public final class VanillaFluidCompat {
         }
 
         private static boolean isValid(BlockState state) {
-            return state.getBlock() == Blocks.CAULDRON && state.contains(CauldronBlock.LEVEL);
+            return state.getBlock() == Blocks.CAULDRON && state.contains(WaterCauldronBlock.LEVEL);
         }
 
         @Override
@@ -189,7 +189,7 @@ public final class VanillaFluidCompat {
         public FluidVolume getInvFluid(int tank) {
             BlockState state = world.getBlockState(pos);
             if (isValid(state)) {
-                int level = state.get(CauldronBlock.LEVEL);
+                int level = state.get(WaterCauldronBlock.LEVEL);
                 return FluidKeys.WATER.withAmount(FluidAmount.of(level, 3));
             }
             return FluidVolumeUtil.EMPTY;
@@ -221,7 +221,7 @@ public final class VanillaFluidCompat {
                 }
 
                 if (simulation.isAction()) {
-                    world.setBlockState(pos, state.with(CauldronBlock.LEVEL, level));
+                    world.setBlockState(pos, state.with(WaterCauldronBlock.LEVEL, level));
                 }
             }
             return false;
@@ -239,7 +239,7 @@ public final class VanillaFluidCompat {
             if (!isValid(state)) {
                 return volume;
             }
-            int current = state.get(CauldronBlock.LEVEL);
+            int current = state.get(WaterCauldronBlock.LEVEL);
             int space = 3 - current;
             if (space <= 0) {
                 return volume;
@@ -250,7 +250,7 @@ public final class VanillaFluidCompat {
             int additional = Math.min(space, bottles);
             incomingFluid.split(FluidAmount.of(additional, 3));
             if (simulation.isAction()) {
-                world.setBlockState(pos, state.with(CauldronBlock.LEVEL, current + additional));
+                world.setBlockState(pos, state.with(WaterCauldronBlock.LEVEL, current + additional));
             }
             return incomingFluid;
         }
@@ -272,7 +272,7 @@ public final class VanillaFluidCompat {
             if (!isValid(state)) {
                 return mergeWith;
             }
-            int current = state.get(CauldronBlock.LEVEL);
+            int current = state.get(WaterCauldronBlock.LEVEL);
             if (current <= 0) {
                 return mergeWith;
             }
@@ -283,7 +283,7 @@ public final class VanillaFluidCompat {
             FluidVolume extracted = FluidKeys.WATER.withAmount(FluidAmount.of(extractedBottles, 3));
 
             if (simulation.isAction()) {
-                world.setBlockState(pos, state.with(CauldronBlock.LEVEL, left));
+                world.setBlockState(pos, state.with(WaterCauldronBlock.LEVEL, left));
             }
 
             if (mergeWith.isEmpty()) {

--- a/src/main/java/alexiil/mc/lib/attributes/fluid/init/ClientFluidInit.java
+++ b/src/main/java/alexiil/mc/lib/attributes/fluid/init/ClientFluidInit.java
@@ -11,14 +11,14 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.event.client.ClientSpriteRegistryCallback;
 
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.texture.SpriteAtlasTexture;
+import net.minecraft.screen.PlayerScreenHandler;
 
 import alexiil.mc.lib.attributes.fluid.volume.PotionFluidKey;
 
 public class ClientFluidInit implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-        ClientSpriteRegistryCallback.event(SpriteAtlasTexture.BLOCK_ATLAS_TEX).register((atlasTexture, registry) -> {
+        ClientSpriteRegistryCallback.event(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE).register((atlasTexture, registry) -> {
             registry.register(PotionFluidKey.POTION_TEXTURE);
         });
 

--- a/src/main/java/alexiil/mc/lib/attributes/fluid/render/EnchantmentGlintFluidRenderer.java
+++ b/src/main/java/alexiil/mc/lib/attributes/fluid/render/EnchantmentGlintFluidRenderer.java
@@ -30,7 +30,7 @@ public class EnchantmentGlintFluidRenderer extends FluidVolumeRenderer {
     ) {
         Sprite[] sprites = getSprites(fluid);
         RenderLayer layer = getRenderLayer(fluid);
-        VertexConsumer vc = ItemRenderer.getGlintVertexConsumer(vcp, layer, true, true);
+        VertexConsumer vc = ItemRenderer.getItemGlintConsumer(vcp, layer, true, true);
         renderSimpleFluid(faces, vc, matrices, sprites[0], sprites[1], fluid.getRenderColor());
     }
 }

--- a/src/main/java/alexiil/mc/lib/attributes/fluid/render/FluidVolumeRenderer.java
+++ b/src/main/java/alexiil/mc/lib/attributes/fluid/render/FluidVolumeRenderer.java
@@ -33,6 +33,7 @@ import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.fluid.Fluid;
+import net.minecraft.screen.PlayerScreenHandler;
 
 import alexiil.mc.lib.attributes.fluid.mixin.impl.RenderLayerAccessor;
 import alexiil.mc.lib.attributes.fluid.volume.FluidVolume;
@@ -98,7 +99,7 @@ public abstract class FluidVolumeRenderer {
                 flowing = still;
             }
         } else {
-            SpriteAtlasTexture atlas = mc.getBakedModelManager().method_24153(SpriteAtlasTexture.BLOCK_ATLAS_TEX);
+            SpriteAtlasTexture atlas = mc.getBakedModelManager().method_24153(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE);
             // Seems odd that Sprite is AutoClosable... but there's nothing we can do about it
             still = atlas.getSprite(fluid.getStillSprite());
             flowing = atlas.getSprite(fluid.getFlowingSprite());

--- a/src/main/java/alexiil/mc/lib/attributes/item/ItemAttributes.java
+++ b/src/main/java/alexiil/mc/lib/attributes/item/ItemAttributes.java
@@ -187,8 +187,7 @@ public final class ItemAttributes {
         });
 
         attribute.appendBlockAdder((w, p, s, l) -> {
-            Block block = s.getBlock();
-            if (!block.hasBlockEntity()) {
+            if (!s.method_31709()) {
                 return;
             }
             Direction direction = l.getSearchDirection();

--- a/src/main/java/alexiil/mc/lib/attributes/item/entity/ItemTransferableItemEntity.java
+++ b/src/main/java/alexiil/mc/lib/attributes/item/entity/ItemTransferableItemEntity.java
@@ -7,6 +7,7 @@
  */
 package alexiil.mc.lib.attributes.item.entity;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.item.ItemStack;
 
@@ -59,7 +60,7 @@ public class ItemTransferableItemEntity implements ItemTransferable {
         if (simulation == Simulation.ACTION) {
             entity.setStack(current);
             if (current.isEmpty()) {
-                entity.remove();
+                entity.remove(Entity.RemovalReason.DISCARDED);
             }
         }
         return extracted;

--- a/src/main/java/alexiil/mc/lib/attributes/item/mixin/HopperHooks.java
+++ b/src/main/java/alexiil/mc/lib/attributes/item/mixin/HopperHooks.java
@@ -75,8 +75,7 @@ public final class HopperHooks {
      *
      * @return {@link ActionResult#PASS} to continue with the original Vanilla logic, otherwise indicates whether
      *         extraction failed or succeeded. */
-    public static ActionResult tryExtract(Hopper hopper) {
-        World world = hopper.getWorld();
+    public static ActionResult tryExtract(World world, Hopper hopper) {
         BlockPos blockAbove = new BlockPos(hopper.getHopperX(), hopper.getHopperY() + 1, hopper.getHopperZ());
 
         if (isVanillaInventoryAt(world, blockAbove)) {

--- a/src/main/java/alexiil/mc/lib/attributes/item/mixin/impl/HopperBlockEntityMixin.java
+++ b/src/main/java/alexiil/mc/lib/attributes/item/mixin/impl/HopperBlockEntityMixin.java
@@ -12,9 +12,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.Hopper;
 import net.minecraft.block.entity.HopperBlockEntity;
+import net.minecraft.inventory.Inventory;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 
 import alexiil.mc.lib.attributes.item.mixin.HopperHooks;
 
@@ -27,17 +31,17 @@ import alexiil.mc.lib.attributes.item.mixin.HopperHooks;
 public class HopperBlockEntityMixin {
 
     @Inject(method = "insert", at = @At("HEAD"), cancellable = true, require = 1, allow = 1)
-    private void onInsert(CallbackInfoReturnable<Boolean> cri) {
-        HopperBlockEntity self = (HopperBlockEntity) (Object) this;
+    private static void onInsert(World world, BlockPos blockPos, BlockState blockState, Inventory inventory, CallbackInfoReturnable<Boolean> cri) {
+        HopperBlockEntity self = (HopperBlockEntity) inventory;
         ActionResult result = HopperHooks.tryInsert(self);
         if (result != ActionResult.PASS) {
             cri.setReturnValue(result.isAccepted());
         }
     }
 
-    @Inject(method = "extract", at = @At("HEAD"), cancellable = true, require = 1, allow = 1)
-    private static void onExtract(Hopper hopper, CallbackInfoReturnable<Boolean> cri) {
-        ActionResult result = HopperHooks.tryExtract(hopper);
+    @Inject(method = "extract(Lnet/minecraft/world/World;Lnet/minecraft/block/entity/Hopper;)Z", at = @At("HEAD"), cancellable = true, require = 1, allow = 1)
+    private static void onExtract(World world, Hopper hopper, CallbackInfoReturnable<Boolean> cri) {
+        ActionResult result = HopperHooks.tryExtract(world, hopper);
         if (result != ActionResult.PASS) {
             cri.setReturnValue(result.isAccepted());
         }

--- a/src/main/java/alexiil/mc/lib/attributes/misc/PlayerInvUtil.java
+++ b/src/main/java/alexiil/mc/lib/attributes/misc/PlayerInvUtil.java
@@ -26,7 +26,7 @@ public final class PlayerInvUtil {
     /** Either inserts the given item into the player's inventory or drops it in front of them. Note that this will
      * always keep a reference to the passed stack (and might modify it!) */
     public static void insertItemIntoPlayerInventory(PlayerEntity player, ItemStack stack) {
-        if (player.inventory.insertStack(stack) && stack.isEmpty()) {
+        if (player.method_31548().insertStack(stack) && stack.isEmpty()) {
             return;
         }
         player.dropItem(stack, /* PreventPlayerQuickPickup = */ false);
@@ -35,8 +35,8 @@ public final class PlayerInvUtil {
     /** Creates a {@link Reference} to the given player's {@link PlayerInventory#getCursorStack() cursor stack}, that
      * updates the client whenever it is changed. */
     public static Reference<ItemStack> referenceGuiCursor(ServerPlayerEntity player) {
-        return Reference.callable(player.inventory::getCursorStack, s -> {
-            player.inventory.setCursorStack(s);
+        return Reference.callable(player.method_31548()::getCursorStack, s -> {
+            player.method_31548().setCursorStack(s);
             player.updateCursorStack();
         }, s -> true);
     }

--- a/src/main/resources/changelog/0.8.5.txt
+++ b/src/main/resources/changelog/0.8.5.txt
@@ -1,0 +1,3 @@
+Changes:
+
+* Updated to be compatible with minecraft 20w45a

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -11,7 +11,7 @@
     ]
   },
   "depends": {
-    "minecraft": [ ">=1.16-rc.4 <1.17-" ],
+    "minecraft": [">=1.17-alpha.20.45.a <1.18-"],
     "fabricloader": ">=0.4.0",
     "fabric": "*"
   },
@@ -63,7 +63,6 @@
         "libblockattributes_fluid.client.json"
       ],
       "~depends": {
-        "+minecraft": [ ">=1.16.2 <1.17-" ],
         "+libblockattributes_core": ">=$version"
       },
       "+icon": "assets/libblockattributes/icon_fluids.png",


### PR DESCRIPTION
Hey, so I don't normally do pull requests, but since you asked for it here it goes. Most of the changes are just fields that became private and now have a getter. 
I didn't know what to do with the RebornCoreCompat since it was instantiating broken block entities and causing the whole project to fail to build, so I just commented the whole file.
Also as I said in Discord, the tests are failing for some reason... Probably something I've done wrong, but I have no idea how these work so I can't fix it, unfortunately.
As far as in-game testing goes, everything in the fluid module I tested is working fine. The only thing that is probably broken is the cauldron vanilla compatibility since Mojang changed how they work (they now have an AbstractCauldron, a WaterCauldron, and a LavaCauldron). Most mods from now on will probably add their own fluid's cauldron variant, so that will need some proper implementation. 
I haven't tested the item module but I don't see any reason why it wouldn't work.
That's all for now, I guess. Let's see what else Mojang breaks next week.