### PR TITLE
Get running on 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ license {
 dependencies {
     minecraft "com.mojang:minecraft:1.19"
     mappings "net.fabricmc:yarn:1.19+build.4:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.13.3"
+    modImplementation "net.fabricmc:fabric-loader:0.14.6"
 
     //Fabric api
     modImplementation "net.fabricmc.fabric-api:fabric-api:0.56.1+1.19"
@@ -109,13 +109,7 @@ tasks.withType(JavaCompile) {
     it.options.release = 17
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
+java.withSourcesJar()
 
 new File("run/").mkdirs();
 

--- a/extra_jar_def.gradle
+++ b/extra_jar_def.gradle
@@ -136,6 +136,7 @@ generateJar("items", itemsReq, [], false, [], ["core"]);
 // 2020/01/23 AlexIIL: Add "fat" jars and the option for optimised compression.
 // 2020/02/22 AlexIIL: Added better error handling when generating fabric.mod.json files.
 // 2021/06/05 AlexIIL: Fixed a few missing task dependencies in gradle 7.
+// 2022/06/23 AlexIIL: Changed input jar (for nested jar extractions) to use remapJar directly, rather than just "jar"
 
 // ==========================================================
 // User config - change both of these on a per-project basis
@@ -183,7 +184,7 @@ ext.extra_jar_def__decompress_external_included = false;
 // Internals - don't touch this!
 // ==============================
 
-ext.extra_jar_def__jarFile = zipTree(jar.archivePath)
+ext.extra_jar_def__jarFile = zipTree(remapJar.archivePath)
 ext.extra_jar_def__modulesDir = new File(System.getenv("LIBS_DIR") ?: "$projectDir/build/libs/", version)
 ext.extra_jar_def__taken = new HashSet<>();
 ext.extra_jar_def__includedJarTasks = new HashSet<String>();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
+# Gradle keeps running out of heap space
+org.gradle.jvmargs=-Xmx1G
+
 reborncore_mc_release=1.18
 reborncore_version=5.1.0-beta.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        jcenter()
+        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/java/alexiil/mc/lib/attributes/item/mixin/impl/DropperBlockMixin.java
+++ b/src/main/java/alexiil/mc/lib/attributes/item/mixin/impl/DropperBlockMixin.java
@@ -28,7 +28,7 @@ public class DropperBlockMixin {
     private static final String DISPENSER_BLOCK_ENTITY = "Lnet/minecraft/block/entity/DispenserBlockEntity;";
 
     @Inject(
-        method = "dispense", at = @At(value = "INVOKE_ASSIGN", target = DISPENSER_BLOCK_ENTITY + "chooseNonEmptySlot()I"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD
+        method = "dispense", at = @At(value = "INVOKE_ASSIGN", target = DISPENSER_BLOCK_ENTITY + "chooseNonEmptySlot(Lnet/minecraft/util/math/random/Random;)I"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD
     )
     void dispenseIntoLba(
         ServerWorld serverWorld, BlockPos pos, CallbackInfo ci, BlockPointerImpl pointer, DispenserBlockEntity be,

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -11,7 +11,7 @@
     ]
   },
   "depends": {
-    "minecraft": [">=1.18-rc.3 <1.19-"],
+    "minecraft": [">=1.19- <1.20-"],
     "fabricloader": ">=0.4.0",
     "fabric": "*"
   },


### PR DESCRIPTION
# This PR
This pull-request makes changes that allow LBA to run in Minecraft 1.19, as well as fixing some simple loom warnings.

# Testing
I have tested that the game runs and can open a world in the development environment.

I have also tested this in conjunction with a 1.19 build of Wired Redstone as well as a 1.19 build of SimplePipes.

# Note
This PR does not change version numbers.