### PR TITLE
Fix Chiseled Bookshelf dupe

### DIFF
--- a/src/main/java/alexiil/mc/lib/attributes/item/compat/FixedInventoryVanillaWrapper.java
+++ b/src/main/java/alexiil/mc/lib/attributes/item/compat/FixedInventoryVanillaWrapper.java
@@ -46,7 +46,11 @@ public class FixedInventoryVanillaWrapper extends FixedInventoryViewVanillaWrapp
         }
         if (allowed) {
             if (simulation == Simulation.ACTION) {
-                inv.setStack(slot, to);
+                if (to.isEmpty()) {
+                    inv.removeStack(slot);
+                } else {
+                    inv.setStack(slot, to);
+                }
                 inv.markDirty();
             }
             return true;

--- a/src/main/java/alexiil/mc/lib/attributes/item/compat/FixedInventoryVanillaWrapper.java
+++ b/src/main/java/alexiil/mc/lib/attributes/item/compat/FixedInventoryVanillaWrapper.java
@@ -29,7 +29,8 @@ public class FixedInventoryVanillaWrapper extends FixedInventoryViewVanillaWrapp
     public boolean setInvStack(int slot, ItemStack to, Simulation simulation) {
         boolean allowed = false;
         ItemStack current = getInvStack(slot);
-        if (to.isEmpty()) {
+        boolean removing = to.isEmpty();
+        if (removing) {
             allowed = canExtract(slot, current);
         } else {
             if (current.isEmpty()) {
@@ -46,7 +47,7 @@ public class FixedInventoryVanillaWrapper extends FixedInventoryViewVanillaWrapp
         }
         if (allowed) {
             if (simulation == Simulation.ACTION) {
-                if (to.isEmpty()) {
+                if (removing) {
                     inv.removeStack(slot);
                 } else {
                     inv.setStack(slot, to);


### PR DESCRIPTION
# This PR
This PR fixes Chiseled Bookshelves duping books due to not being willing to set a slot to an empty stack.

# Implementation Notes
This uses a mixin into `ChiseledBookshelfBlockEntity` to implement a new `CustomLogicInventory` which `FixedInventoryVanillaWrapper` then checks for.